### PR TITLE
Added README with CodeClimate and Travis CI badges

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,0 @@
-plugin :
-  checkstyle :
-    enabled: true
-  sonar-java:
-    enabled : true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+**Travis CI**
+[![Build Status](https://travis-ci.org/Susanfe/sdp-event-management.svg?branch=master)](https://travis-ci.org/Susanfe/sdp-event-management)
+
+
+**CodeClimate**
+[![Maintainability](https://api.codeclimate.com/v1/badges/5bfca0ae643017ba74c0/maintainability)](https://codeclimate.com/github/Susanfe/sdp-event-management/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/5bfca0ae643017ba74c0/test_coverage)](https://codeclimate.com/github/Susanfe/sdp-event-management/test_coverage)
+


### PR DESCRIPTION
Just to add the README with Travis CI and CodeClimate badges.
As CodeClimate testing has to be set, the .codeclimate.yml file is deleted for now in order to set the default CC code coverage.