### PR TITLE
Refactor: rename `Concert` to `ScheduledItem`

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/ScheduledItemRepository.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/ScheduledItemRepository.java
@@ -4,30 +4,26 @@ import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.support.annotation.NonNull;
 import android.util.Log;
-import ch.epfl.sweng.eventmanager.repository.data.Concert;
-import ch.epfl.sweng.eventmanager.repository.data.Event;
+import ch.epfl.sweng.eventmanager.repository.data.ScheduledItem;
 import com.google.firebase.database.*;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Collections;
-import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
  * @author Louis Vialar
  */
 @Singleton
-public class ConcertRepository {
-    private static final String TAG = "ConcertRepository";
+public class ScheduledItemRepository {
+    private static final String TAG = "ScheduledItemRepository";
 
     @Inject
-    public ConcertRepository() {
+    public ScheduledItemRepository() {
     }
 
-    public LiveData<List<Concert>> getConcerts(int eventId) {
-        final MutableLiveData<List<Concert>> data = new MutableLiveData<>();
+    public LiveData<List<ScheduledItem>> getConcerts(int eventId) {
+        final MutableLiveData<List<ScheduledItem>> data = new MutableLiveData<>();
         DatabaseReference dbRef = FirebaseDatabase.getInstance()
                 .getReference("schedule_items")
                 .child("event_" + eventId);
@@ -35,11 +31,11 @@ public class ConcertRepository {
         dbRef.addValueEventListener(new ValueEventListener() {
             @Override
             public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                GenericTypeIndicator<List<Concert>> typeToken = new GenericTypeIndicator<List<Concert>>() {
+                GenericTypeIndicator<List<ScheduledItem>> typeToken = new GenericTypeIndicator<List<ScheduledItem>>() {
                 };
 
-                List<Concert> concerts = dataSnapshot.getValue(typeToken);
-                data.postValue(concerts);
+                List<ScheduledItem> scheduledItems = dataSnapshot.getValue(typeToken);
+                data.postValue(scheduledItems);
             }
 
             @Override

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/ScheduledItem.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/ScheduledItem.java
@@ -4,6 +4,7 @@ package ch.epfl.sweng.eventmanager.repository.data;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.UUID;
 
 /**
  * Class describing a single scheduled item (concert, activity...) in an event. The class is for the moment only used by
@@ -37,14 +38,34 @@ public final class ScheduledItem {
      */
     private double duration;
 
+    /**
+     * An UUID identifying this scheduled item uniquely
+     */
+    private UUID id;
+
+    /**
+     * The type of the item<br>
+     * It would make sense to have an enum, but a single string allows the organizer to defines its own types of items
+     */
+    private String itemType;
+
+    /**
+     * The place (room, usually) where the event takes place<br>
+     *     // FIXME Depending on how the map works, we might want to add more data here so that the user can click and go to the map.
+     */
+    private String itemLocation;
+
     private static final double STANDARD_DURATION = 1;
 
-    public ScheduledItem(Date date, String artist, String genre, String description, double duration) {
+    public ScheduledItem(Date date, String artist, String genre, String description, double duration, UUID id, String itemType, String itemLocation) {
         this.date = date.getTime();
         this.artist = artist;
         this.genre = genre;
         this.description = description;
         this.duration = duration;
+        this.id = id;
+        this.itemType = itemType;
+        this.itemLocation = itemLocation;
     }
 
     public ScheduledItem() {}
@@ -72,6 +93,10 @@ public final class ScheduledItem {
         return duration;
     }
 
+    public UUID getId() {
+        return id;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof ScheduledItem) {
@@ -83,6 +108,14 @@ public final class ScheduledItem {
 
     public String dateAsString() {
         return new Date(date).toString();
+    }
+
+    public String getItemType() {
+        return itemType;
+    }
+
+    public String getItemLocation() {
+        return itemLocation;
     }
 
     public Date getEndOfConcert() {
@@ -99,26 +132,26 @@ public final class ScheduledItem {
         return calendar.getTime();
     }
 
-    public ConcertStatus getStatus() {
+    public ScheduledItemStatus getStatus() {
         // If we don't have a date, it's in the future
         if (getDate() == null) {
-            return ConcertStatus.NOT_STARTED;
+            return ScheduledItemStatus.NOT_STARTED;
         }
 
         Date currentDate = new Date();
 
         if (currentDate.after(getDate())) {
             if (currentDate.before(getEndOfConcert())) {
-                return ConcertStatus.IN_PROGRESS; //concert is taking place
+                return ScheduledItemStatus.IN_PROGRESS; //concert is taking place
             } else {
-                return ConcertStatus.NOT_STARTED; //concert is later
+                return ScheduledItemStatus.NOT_STARTED; //concert is later
             }
         } else {
-            return ConcertStatus.PASSED; //concert happened
+            return ScheduledItemStatus.PASSED; //concert happened
         }
     }
 
-    public static enum ConcertStatus {
+    public static enum ScheduledItemStatus {
         /**
          * The concert already happened
          */

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/ScheduledItem.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/ScheduledItem.java
@@ -6,10 +6,10 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 
 /**
- * Class describing a single concert in an event. The class is for the moment only used by the
- * ScheduleActivity.
+ * Class describing a single scheduled item (concert, activity...) in an event. The class is for the moment only used by
+ * the ScheduleActivity.
  */
-public final class Concert {
+public final class ScheduledItem {
     /**
      * Indicates the time of the concert, precision required is minutes.
      *
@@ -39,7 +39,7 @@ public final class Concert {
 
     private static final double STANDARD_DURATION = 1;
 
-    public Concert(Date date, String artist, String genre, String description, double duration) {
+    public ScheduledItem(Date date, String artist, String genre, String description, double duration) {
         this.date = date.getTime();
         this.artist = artist;
         this.genre = genre;
@@ -47,7 +47,7 @@ public final class Concert {
         this.duration = duration;
     }
 
-    public Concert() {}
+    public ScheduledItem() {}
 
     public Date getDate() {
         if (date <= 0) {
@@ -74,8 +74,8 @@ public final class Concert {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof Concert) {
-            Concert compared = (Concert) obj;
+        if (obj instanceof ScheduledItem) {
+            ScheduledItem compared = (ScheduledItem) obj;
             return compared.date == date && compared.artist.equals(artist) &&
                     compared.genre.equals(genre) && compared.duration==duration;
         } else return super.equals(obj);

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/schedule/ScheduleActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/schedule/ScheduleActivity.java
@@ -8,15 +8,11 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import ch.epfl.sweng.eventmanager.R;
-import ch.epfl.sweng.eventmanager.repository.data.Concert;
 import ch.epfl.sweng.eventmanager.ui.eventSelector.EventPickingActivity;
 import ch.epfl.sweng.eventmanager.viewmodel.ViewModelFactory;
 import dagger.android.AndroidInjection;
 
 import javax.inject.Inject;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
 
 public class ScheduleActivity extends AppCompatActivity {
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/schedule/ScheduleViewModel.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/schedule/ScheduleViewModel.java
@@ -2,10 +2,8 @@ package ch.epfl.sweng.eventmanager.ui.schedule;
 
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.ViewModel;
-import ch.epfl.sweng.eventmanager.repository.ConcertRepository;
-import ch.epfl.sweng.eventmanager.repository.EventRepository;
-import ch.epfl.sweng.eventmanager.repository.data.Concert;
-import ch.epfl.sweng.eventmanager.repository.data.Event;
+import ch.epfl.sweng.eventmanager.repository.ScheduledItemRepository;
+import ch.epfl.sweng.eventmanager.repository.data.ScheduledItem;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -17,12 +15,12 @@ import java.util.List;
  * @author Louis Vialar
  */
 public class ScheduleViewModel extends ViewModel {
-    private LiveData<List<Concert>> concerts;
+    private LiveData<List<ScheduledItem>> concerts;
 
-    private ConcertRepository repository;
+    private ScheduledItemRepository repository;
 
     @Inject
-    public ScheduleViewModel(ConcertRepository repository) {
+    public ScheduleViewModel(ScheduledItemRepository repository) {
         this.repository = repository;
     }
 
@@ -34,7 +32,7 @@ public class ScheduleViewModel extends ViewModel {
         this.concerts = repository.getConcerts(eventId);
     }
 
-    public LiveData<List<Concert>> getConcerts() {
+    public LiveData<List<ScheduledItem>> getConcerts() {
         return concerts;
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/schedule/TimeLineAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/schedule/TimeLineAdapter.java
@@ -61,12 +61,12 @@ public class TimeLineAdapter extends RecyclerView.Adapter<TimeLineViewHolder> {
         holder.mDescription.setText(descriptionText);
         holder.mDuration.setText(durationText);
 
-        ScheduledItem.ConcertStatus status = scheduledItem.getStatus();
+        ScheduledItem.ScheduledItemStatus status = scheduledItem.getStatus();
 
         // Sets Marker according to the scheduledItem status
-        if (status == ScheduledItem.ConcertStatus.PASSED) {
+        if (status == ScheduledItem.ScheduledItemStatus.PASSED) {
             holder.mTimelineView.setMarker(getMarkerDrawable(context, R.drawable.ic_marker_inactive, android.R.color.darker_gray));
-        } else if (status == ScheduledItem.ConcertStatus.IN_PROGRESS) {
+        } else if (status == ScheduledItem.ScheduledItemStatus.IN_PROGRESS) {
             holder.mTimelineView.setMarker(getMarkerDrawable(context, R.drawable.ic_marker_active, R.color.colorPrimary));
         } else {
             holder.mTimelineView.setMarker(ContextCompat.getDrawable(context, R.drawable.ic_marker), ContextCompat.getColor(context, R.color.colorPrimary));

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/schedule/TimeLineAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/schedule/TimeLineAdapter.java
@@ -12,7 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import ch.epfl.sweng.eventmanager.repository.data.Concert;
+import ch.epfl.sweng.eventmanager.repository.data.ScheduledItem;
 import com.github.vipulasri.timelineview.TimelineView;
 
 import java.util.List;
@@ -22,11 +22,11 @@ import ch.epfl.sweng.eventmanager.R;
 
 public class TimeLineAdapter extends RecyclerView.Adapter<TimeLineViewHolder> {
 
-    private List<Concert> dataList;
+    private List<ScheduledItem> dataList;
     private Context context;
     private LayoutInflater mLayoutInflater;
 
-    public TimeLineAdapter(List<Concert> feedList) {
+    public TimeLineAdapter(List<ScheduledItem> feedList) {
         dataList = feedList;
     }
 
@@ -47,13 +47,13 @@ public class TimeLineAdapter extends RecyclerView.Adapter<TimeLineViewHolder> {
     @Override
     public void onBindViewHolder(@NonNull TimeLineViewHolder holder, int position) {
 
-        Concert concert = dataList.get(position);
+        ScheduledItem scheduledItem = dataList.get(position);
 
-        String artistText = concert.getArtist() == null ? context.getString(R.string.concert_no_artist) : concert.getArtist();
-        String dateText = concert.dateAsString() == null ? context.getString(R.string.concert_no_date) : concert.dateAsString();
-        String genreText = concert.getGenre() == null ? context.getString(R.string.concert_no_genre) : concert.getGenre();
-        String descriptionText = concert.getDescription() == null ? context.getString(R.string.concert_no_genre) : concert.getDescription();
-        String durationText = transformDuration(concert.getDuration());
+        String artistText = scheduledItem.getArtist() == null ? context.getString(R.string.concert_no_artist) : scheduledItem.getArtist();
+        String dateText = scheduledItem.dateAsString() == null ? context.getString(R.string.concert_no_date) : scheduledItem.dateAsString();
+        String genreText = scheduledItem.getGenre() == null ? context.getString(R.string.concert_no_genre) : scheduledItem.getGenre();
+        String descriptionText = scheduledItem.getDescription() == null ? context.getString(R.string.concert_no_genre) : scheduledItem.getDescription();
+        String durationText = transformDuration(scheduledItem.getDuration());
 
         holder.mArtist.setText(artistText);
         holder.mDate.setText(dateText);
@@ -61,12 +61,12 @@ public class TimeLineAdapter extends RecyclerView.Adapter<TimeLineViewHolder> {
         holder.mDescription.setText(descriptionText);
         holder.mDuration.setText(durationText);
 
-        Concert.ConcertStatus status = concert.getStatus();
+        ScheduledItem.ConcertStatus status = scheduledItem.getStatus();
 
-        // Sets Marker according to the concert status
-        if (status == Concert.ConcertStatus.PASSED) {
+        // Sets Marker according to the scheduledItem status
+        if (status == ScheduledItem.ConcertStatus.PASSED) {
             holder.mTimelineView.setMarker(getMarkerDrawable(context, R.drawable.ic_marker_inactive, android.R.color.darker_gray));
-        } else if (status == Concert.ConcertStatus.IN_PROGRESS) {
+        } else if (status == ScheduledItem.ConcertStatus.IN_PROGRESS) {
             holder.mTimelineView.setMarker(getMarkerDrawable(context, R.drawable.ic_marker_active, R.color.colorPrimary));
         } else {
             holder.mTimelineView.setMarker(ContextCompat.getDrawable(context, R.drawable.ic_marker), ContextCompat.getColor(context, R.color.colorPrimary));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="title_activity_event_picking">EventPickingActivity</string>
     <string name="concert_no_artist">Unknown artist</string>
     <string name="concert_no_genre">Unknown genre</string>
-    <string name="concert_no_description">Sorry ! There is no description for this scheduledItem :/</string>
+    <string name="concert_no_description">Sorry ! There is no description for this concert :/</string>
     <string name="concert_no_date">2018–1–1 20:30</string>
 
     <string name="title_activity_join_event_switch">Join the event</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="title_activity_event_picking">EventPickingActivity</string>
     <string name="concert_no_artist">Unknown artist</string>
     <string name="concert_no_genre">Unknown genre</string>
-    <string name="concert_no_description">Sorry ! There is no description for this concert :/</string>
+    <string name="concert_no_description">Sorry ! There is no description for this scheduledItem :/</string>
     <string name="concert_no_date">2018–1–1 20:30</string>
 
     <string name="title_activity_join_event_switch">Join the event</string>


### PR DESCRIPTION
As we discussed wednesday, events can have more activities than just `Concert`. I renamed the class to `ScheduledItem` accordingly. I also added a few useful fields for the next issues.