### PR TITLE
Schedule Parent Fragment

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/myschedule/MyScheduleTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/myschedule/MyScheduleTest.java
@@ -1,16 +1,11 @@
 package ch.epfl.sweng.eventmanager.ui.myschedule;
 
-import android.content.Context;
 import android.content.Intent;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.espresso.UiController;
-import android.support.test.espresso.ViewAction;
-import android.support.test.espresso.ViewInteraction;
+import android.os.SystemClock;
 import android.support.test.espresso.contrib.DrawerActions;
 import android.support.test.espresso.contrib.NavigationViewActions;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import ch.epfl.sweng.eventmanager.R;
@@ -23,14 +18,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.*;
+import static android.support.test.espresso.action.ViewActions.longClick;
+import static android.support.test.espresso.action.ViewActions.swipeRight;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.contrib.DrawerMatchers.isClosed;
+import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static junit.framework.TestCase.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class MyScheduleTest {
@@ -53,17 +47,14 @@ public class MyScheduleTest {
         onView(withId(R.id.nav_view))
                 .perform(NavigationViewActions.navigateTo(R.id.nav_schedule));
 
+        onView(withId(R.id.viewpager)).check(matches(isCompletelyDisplayed()));
+
         // Add first element of scheduledItems to MySchedule
         onView(withIndex(withId(R.id.text_timeline_description), 0)).perform(longClick());
+        SystemClock.sleep(800);
 
-        onView(withId(R.id.drawer_layout))
-                .check(matches(isClosed(Gravity.LEFT)))
-                .perform(DrawerActions.open());
-
-        onView(withId(R.id.nav_view))
-                .perform(NavigationViewActions.navigateTo(R.id.nav_schedule));
-
-        onView(withId(R.id.viewpager)).perform(swipeLeft());
+        onView(withId(R.id.viewpager)).perform(swipeRight()).check(matches(isCompletelyDisplayed()));
+        SystemClock.sleep(800);
 
         // Delete first element of scheduledItems from MySchedule
         onView(withIndex(withId(R.id.text_timeline_description), 0)).perform(longClick());

--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/myschedule/MyScheduleTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/myschedule/MyScheduleTest.java
@@ -25,8 +25,7 @@ import org.junit.runner.RunWith;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.longClick;
+import static android.support.test.espresso.action.ViewActions.*;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.contrib.DrawerMatchers.isClosed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
@@ -62,7 +61,9 @@ public class MyScheduleTest {
                 .perform(DrawerActions.open());
 
         onView(withId(R.id.nav_view))
-                .perform(NavigationViewActions.navigateTo(R.id.nav_my_schedule));
+                .perform(NavigationViewActions.navigateTo(R.id.nav_schedule));
+
+        onView(withId(R.id.viewpager)).perform(swipeLeft());
 
         // Delete first element of scheduledItems from MySchedule
         onView(withIndex(withId(R.id.text_timeline_description), 0)).perform(longClick());

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
@@ -2,6 +2,7 @@ package ch.epfl.sweng.eventmanager.ui.eventShowcase;
 
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -21,9 +22,8 @@ import ch.epfl.sweng.eventmanager.R;
 import ch.epfl.sweng.eventmanager.ui.eventSelector.EventPickingActivity;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.EventMainFragment;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.EventMapFragment;
+import ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.schedule.ScheduleParentFragment;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.models.EventShowcaseModel;
-import ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.schedule.MyScheduleFragment;
-import ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.schedule.ScheduleFragment;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.models.ScheduleViewModel;
 import ch.epfl.sweng.eventmanager.viewmodel.ViewModelFactory;
 import dagger.android.AndroidInjection;
@@ -52,9 +52,11 @@ public class EventShowcaseActivity extends AppCompatActivity
         setSupportActionBar(toolbar);
 
         // Add drawer button to the action bar
-        ActionBar actionbar = getSupportActionBar();
-        actionbar.setDisplayHomeAsUpEnabled(true);
-        actionbar.setHomeAsUpIndicator(R.drawable.ic_menu);
+        if(getSupportActionBar() != null) {
+            ActionBar actionbar = getSupportActionBar();
+            actionbar.setDisplayHomeAsUpEnabled(true);
+            actionbar.setHomeAsUpIndicator(R.drawable.ic_menu);
+        }
 
         // Fetch event from passed ID
         Intent intent = getIntent();
@@ -87,7 +89,7 @@ public class EventShowcaseActivity extends AppCompatActivity
     }
 
     @Override
-    public boolean onNavigationItemSelected(MenuItem menuItem) {
+    public boolean onNavigationItemSelected(@NonNull MenuItem menuItem) {
         // set item as selected to persist highlight
         menuItem.setChecked(true);
 
@@ -113,12 +115,9 @@ public class EventShowcaseActivity extends AppCompatActivity
                 break;
 
             case R.id.nav_schedule :
-                changeFragment(new ScheduleFragment(), true);
+                changeFragment(new ScheduleParentFragment(), true);
                 break;
 
-            case R.id.nav_my_schedule :
-                changeFragment(new MyScheduleFragment(), true);
-                break;
         }
 
         return true;

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/AbstractScheduleFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/AbstractScheduleFragment.java
@@ -40,6 +40,7 @@ public abstract class AbstractScheduleFragment extends Fragment {
         View view = inflater.inflate(R.layout.activity_schedule, container, false);
 
         ButterKnife.bind(this,view);
+        setNullConcertsTV();
         recyclerView.setLayoutManager(new LinearLayoutManager(view.getContext()));
         recyclerView.setHasFixedSize(true);
 
@@ -60,7 +61,7 @@ public abstract class AbstractScheduleFragment extends Fragment {
         }
 
         this.getScheduledItems().observe(this, concerts -> {
-            if (concerts != null) {
+            if (concerts != null && concerts.size() > 0) {
                 nullConcertsTV.setVisibility(View.GONE);
                 recyclerView.setVisibility(View.VISIBLE);
                 Collections.sort(concerts,(c1,c2) -> Objects.requireNonNull(c1.getDate()).compareTo(c2.getDate()));
@@ -79,6 +80,7 @@ public abstract class AbstractScheduleFragment extends Fragment {
         model = ViewModelProviders.of(requireActivity()).get(ScheduleViewModel.class);
     }
 
+    protected abstract void setNullConcertsTV();
 
     protected abstract LiveData<List<ScheduledItem>> getScheduledItems();
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/AbstractScheduleFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/AbstractScheduleFragment.java
@@ -70,9 +70,11 @@ public abstract class AbstractScheduleFragment extends Fragment {
       * @param view view
       */
     private void showAlertOnEmptyConcerts(View view) {
-         AlertDialog.Builder myAlert = new AlertDialog.Builder(getActivity());
-         myAlert.setMessage(R.string.concerts_empty).create();
-         myAlert.show();
+         AlertDialog.Builder nullConcertsAlert = new AlertDialog.Builder(getActivity());
+         nullConcertsAlert.setMessage(R.string.concerts_empty).create();
+         nullConcertsAlert.setOnDismissListener(dialog -> getActivity().onBackPressed());
+         nullConcertsAlert.show();
+
      }
 
     @Override

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/MyScheduleFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/MyScheduleFragment.java
@@ -1,11 +1,17 @@
 package ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.schedule;
 
 import android.arch.lifecycle.LiveData;
+import ch.epfl.sweng.eventmanager.R;
 import ch.epfl.sweng.eventmanager.repository.data.ScheduledItem;
 
 import java.util.List;
 
 public class MyScheduleFragment extends AbstractScheduleFragment {
+    @Override
+    protected void setNullConcertsTV() {
+        super.nullConcertsTV.setText(R.string.my_schedule_empty);
+    }
+
     @Override
     protected LiveData<List<ScheduledItem>> getScheduledItems() {
         return this.model.getJoinedScheduleItems();

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/ScheduleFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/ScheduleFragment.java
@@ -1,11 +1,17 @@
 package ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.schedule;
 
 import android.arch.lifecycle.LiveData;
+import ch.epfl.sweng.eventmanager.R;
 import ch.epfl.sweng.eventmanager.repository.data.ScheduledItem;
 
 import java.util.List;
 
 public class ScheduleFragment extends AbstractScheduleFragment {
+    @Override
+    protected void setNullConcertsTV() {
+        super.nullConcertsTV.setText(R.string.concerts_empty);
+    }
+
     @Override
     protected LiveData<List<ScheduledItem>> getScheduledItems() {
         return this.model.getScheduledItems();

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/ScheduleParentFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/schedule/ScheduleParentFragment.java
@@ -1,0 +1,95 @@
+package ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.schedule;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.TabLayout;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import ch.epfl.sweng.eventmanager.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fragment with viewPager holding Schedule and mySchedule fragments
+ */
+public class ScheduleParentFragment extends Fragment {
+
+    @BindView(R.id.viewpager)
+    ViewPager viewPager;
+    @BindView(R.id.tabs)
+    TabLayout tabLayout;
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+
+        //Create view and bindings
+        View view = inflater.inflate(R.layout.fragment_schedule_parent,container, false);
+        ButterKnife.bind(this,view);
+
+        //Setup the ViewPager
+        createViewPager(viewPager);
+        tabLayout.setupWithViewPager(viewPager);
+
+        return view;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+
+    /**
+     * Take care of setting up the viewPager Adapter and binding it to the viewPager
+     * @param viewPager viewpager
+     */
+    private void createViewPager (ViewPager viewPager) {
+        ViewPagerAdapter viewPagerAdapter = new ViewPagerAdapter(getChildFragmentManager());
+        viewPagerAdapter.addFragment(new ScheduleFragment(), "Schedule");
+        viewPagerAdapter.addFragment(new MyScheduleFragment(), "My Schedule");
+        viewPager.setAdapter(viewPagerAdapter);
+
+    }
+
+    /**
+     * Basic Adapter for ViewPager
+     */
+    static class ViewPagerAdapter extends FragmentPagerAdapter {
+        private final List<Fragment> mFragmentList = new ArrayList<>();
+        private final List<String> mFragmentTitleList = new ArrayList<>();
+
+        ViewPagerAdapter(FragmentManager manager) {
+            super(manager);
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            return mFragmentList.get(position);
+        }
+
+        @Override
+        public int getCount() {
+            return mFragmentList.size();
+        }
+
+        void addFragment(Fragment fragment, String title) {
+            mFragmentList.add(fragment);
+            mFragmentTitleList.add(title);
+        }
+
+        @Override
+        public CharSequence getPageTitle(int position) {
+            return mFragmentTitleList.get(position);
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_schedule.xml
+++ b/app/src/main/res/layout/activity_schedule.xml
@@ -1,14 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
+        xmlns:app="http://schemas.android.com/apk/res-auto" xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.eventShowcase.fragments.schedule.ScheduleFragment"
-        android:layout_marginTop="?attr/actionBarSize">
+        android:layout_marginTop="?android:attr/actionBarSize">
 
 
-    <include layout="@layout/content_timeline"></include>
+    <include layout="@layout/content_timeline" android:id="@+id/include"/>
+
+    <TextView
+            android:text="@string/concerts_empty"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" android:id="@+id/concerts_empty_tv"
+            android:gravity="center"
+            app:layout_anchorGravity="center_vertical|center_horizontal"
+            app:layout_anchor="@+id/include" android:visibility="gone"/>
 
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_schedule_parent.xml
+++ b/app/src/main/res/layout/fragment_schedule_parent.xml
@@ -6,32 +6,32 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?android:attr/actionBarSize"
-        tools:context=".ui.eventShowcase.fragments.schedule.ScheduleParentFragment">
+        tools:context=".ui.eventShowcase.fragments.schedule.ScheduleParentFragment"
+        android:id="@+id/main_content">
 
-<android.support.design.widget.CoordinatorLayout
-        android:id="@+id/main_content"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-    <android.support.design.widget.AppBarLayout
+    <android.support.design.widget.CoordinatorLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:theme="@style/AppTheme.AppBarOverlay"
-            android:background="@color/colorPrimaryDark">
+            android:layout_height="match_parent">
 
-        <android.support.design.widget.TabLayout
-                android:id="@+id/tabs"
+        <android.support.design.widget.AppBarLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:tabMode="fixed"
-                app:tabGravity="fill"/>
-    </android.support.design.widget.AppBarLayout>
+                android:theme="@style/AppTheme.AppBarOverlay"
+                android:background="@color/colorPrimaryDark">
 
-    <android.support.v4.view.ViewPager
-            android:id="@+id/viewpager"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"  />
-</android.support.design.widget.CoordinatorLayout>
+            <android.support.design.widget.TabLayout
+                    android:id="@+id/tabs"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:tabMode="fixed"
+                    app:tabGravity="fill"/>
+        </android.support.design.widget.AppBarLayout>
+
+        <android.support.v4.view.ViewPager
+                android:id="@+id/viewpager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+    </android.support.design.widget.CoordinatorLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_schedule_parent.xml
+++ b/app/src/main/res/layout/fragment_schedule_parent.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="?android:attr/actionBarSize"
+        tools:context=".ui.eventShowcase.fragments.schedule.ScheduleParentFragment">
+
+<android.support.design.widget.CoordinatorLayout
+        android:id="@+id/main_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <android.support.design.widget.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/AppTheme.AppBarOverlay"
+            android:background="@color/colorPrimaryDark">
+
+        <android.support.design.widget.TabLayout
+                android:id="@+id/tabs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:tabMode="fixed"
+                app:tabGravity="fill"/>
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.view.ViewPager
+            android:id="@+id/viewpager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"  />
+</android.support.design.widget.CoordinatorLayout>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/event_showcase_drawer_view.xml
+++ b/app/src/main/res/menu/event_showcase_drawer_view.xml
@@ -11,9 +11,6 @@
             android:id="@+id/nav_schedule"
             android:title="@string/schedule_nav_item_activity_event_showcase" />
         <item
-            android:id="@+id/nav_my_schedule"
-            android:title="@string/my_schedule_nav_item_activity_event_showcase" />
-        <item
             android:id="@+id/nav_tickets"
             android:title="@string/ticket_nav_item_activity_event_showcase" />
         <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="concert_no_description">Sorry ! There is no description for this concert :/</string>
     <string name="concert_no_date">2018–1–1 20:30</string>
     <string name="concerts_empty">Sorry ! There are no registered concerts for this event :/</string>
+    <string name="my_schedule_empty">There is currently no saved concerts for this event</string>
 
     <string name="title_activity_join_event_switch">Join the event</string>
     <string name="title_activity_login">Sign in</string>
@@ -37,5 +38,4 @@
     <string name="timeline_view_removed_from_own_schedule">Event removed from your schedule!</string>
     <string name="my_schedule_nav_item_activity_event_showcase">My Schedule</string>
 
-    <string name="dialog_ok">OK !</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,6 @@
     <string name="timeline_view_added_to_own_schedule">Event added to your schedule!</string>
     <string name="timeline_view_removed_from_own_schedule">Event removed from your schedule!</string>
     <string name="my_schedule_nav_item_activity_event_showcase">My Schedule</string>
+
+    <string name="dialog_ok">OK !</string>
 </resources>


### PR DESCRIPTION
Grouped schedule and my Schedule in a tab Layout allowing the user to either display the global schedule or its own schedule easily. This is more intuitive than having to use the global drawer to either choose schedule or my schedule as schedule and my schedule are closely related.
As a bonus, changed the way of letting know the user if there are no registered concerts for this event by displaying a text on the fragment. Same, an informative text is now displayed when the user didn't add any events to its own schedule