### PR TITLE
Bug/fix back navigation

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivityTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.pressBack;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.contrib.DrawerMatchers.isClosed;
@@ -44,18 +45,28 @@ public class EventShowcaseActivityTest {
 
         onIdle();
 
-
-        // Open event picker
-        String help_text = getResourceString(R.string.help_text_activity_event_picking);
+        //test back navigation
         onView(withId(R.id.drawer_layout))
                 .perform(DrawerActions.open());
+        onView(withId(R.id.nav_view)).perform(NavigationViewActions.navigateTo(R.id.nav_schedule));
+        pressBack();
+        onView(withId(R.id.drawer_layout))
+                .perform(DrawerActions.open());
+        onView(withId(R.id.nav_view)).perform(NavigationViewActions.navigateTo(R.id.nav_map));
+        pressBack();
+        pressBack();
+    }
 
-        onIdle();
+    @Test
+    public void openEventPicker() {
+        Intent intent = new Intent();
+        intent.putExtra(EventPickingActivity.SELECTED_EVENT_ID, 1);
+        mActivityRule.launchActivity(intent);
+        onView(withId(R.id.drawer_layout))
+                .perform(DrawerActions.open());
+        onView(withId(R.id.nav_view)).perform(NavigationViewActions.navigateTo(R.id.nav_pick_event));
 
-        onView(withId(R.id.nav_view))
-                .perform(NavigationViewActions.navigateTo(R.id.nav_pick_event));
-
-        onIdle();
+        String help_text = getResourceString(R.string.help_text_activity_event_picking);
 
         onView(withId(R.id.help_text))
                 .check(matches(withText(help_text)));
@@ -92,4 +103,5 @@ public class EventShowcaseActivityTest {
         onView(withText("Japan Impact")).perform(click());
 
     }
+
 }

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
@@ -17,6 +17,8 @@ import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
+import butterknife.BindView;
+import butterknife.ButterKnife;
 import ch.epfl.sweng.eventmanager.R;
 import ch.epfl.sweng.eventmanager.ui.eventSelector.EventPickingActivity;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.EventMainFragment;
@@ -40,12 +42,18 @@ public class EventShowcaseActivity extends AppCompatActivity
     @Inject
     ViewModelFactory factory;
 
+    @BindView(R.id.drawer_layout)
+    private DrawerLayout mDrawerLayout;
+    @BindView(R.id.nav_view)
+    private NavigationView navigationView;
+    @BindView(R.id.toolbar)
+    private Toolbar toolbar;
+
     private EventShowcaseModel model;
     private ScheduleViewModel scheduleModel;
     private NewsViewModel newsModel;
     private SpotsModel spotsModel;
-    private DrawerLayout mDrawerLayout;
-    private NavigationView navigationView;
+
 
     private void initModels(int eventID) {
         this.model = ViewModelProviders.of(this, factory).get(EventShowcaseModel.class);
@@ -82,11 +90,9 @@ public class EventShowcaseActivity extends AppCompatActivity
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_event_showcase);
-        mDrawerLayout = findViewById(R.id.drawer_layout);
-        this.navigationView = findViewById(R.id.nav_view);
+        ButterKnife.bind(this);
 
         // Set toolbar as action bar
-        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         // Add drawer button to the action bar
@@ -103,7 +109,6 @@ public class EventShowcaseActivity extends AppCompatActivity
             Log.e(TAG, "Got invalid event ID#" + eventID + ".");
         } else {
             this.initModels(eventID);
-
             this.setupHeader();
 
             // Set displayed fragment
@@ -227,10 +232,16 @@ public class EventShowcaseActivity extends AppCompatActivity
         }
     }
 
+    /**
+     * @return currentFragment
+     */
     private Fragment getCurrentFragment() {
         return getSupportFragmentManager().findFragmentById(R.id.content_frame);
     }
 
+    /**
+     * Handles back button
+     */
     @Override
     public void onBackPressed() {
         Fragment fragment = getCurrentFragment();

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
@@ -43,11 +43,11 @@ public class EventShowcaseActivity extends AppCompatActivity
     ViewModelFactory factory;
 
     @BindView(R.id.drawer_layout)
-    private DrawerLayout mDrawerLayout;
+    DrawerLayout mDrawerLayout;
     @BindView(R.id.nav_view)
-    private NavigationView navigationView;
+    NavigationView navigationView;
     @BindView(R.id.toolbar)
-    private Toolbar toolbar;
+    Toolbar toolbar;
 
     private EventShowcaseModel model;
     private ScheduleViewModel scheduleModel;

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
@@ -139,23 +139,23 @@ public class EventShowcaseActivity extends AppCompatActivity
                 break;
 
             case R.id.nav_main :
-                changeFragment(new EventMainFragment(), true);
+                changeFragment(new EventMainFragment(), false);
                 break;
 
             case R.id.nav_map :
-                changeFragment(new EventMapFragment(), true);
+                changeFragment(new EventMapFragment(), false);
                 break;
 
             case R.id.nav_tickets :
-                changeFragment(new EventMapFragment(), true);
+                changeFragment(new EventMapFragment(), false);
                 break;
 
             case R.id.nav_news :
-                changeFragment(new NewsFragment(), true);
+                changeFragment(new NewsFragment(), false);
                 break;
 
             case R.id.nav_schedule :
-                changeFragment(new ScheduleParentFragment(), true);
+                changeFragment(new ScheduleParentFragment(), false);
                 break;
 
         }
@@ -200,6 +200,17 @@ public class EventShowcaseActivity extends AppCompatActivity
                     "Unable to commit fragment, could be activity as been killed in background. "
                             + exception.toString()
             );
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        int count = getSupportFragmentManager().getBackStackEntryCount();
+        if (count > 0) {
+            getSupportFragmentManager().popBackStack();
+            changeFragment(new EventMainFragment(),false);
+        } else {
+            super.onBackPressed();
         }
     }
 }

--- a/app/src/main/res/menu/event_showcase_drawer_view.xml
+++ b/app/src/main/res/menu/event_showcase_drawer_view.xml
@@ -3,8 +3,7 @@
     <group android:checkableBehavior="single">
         <item
                 android:id="@+id/nav_main"
-                android:title="@string/main_nav_item_activity_event_showcase"
-                android:checked="true"/>
+                android:title="@string/main_nav_item_activity_event_showcase"/>
         <item
                 android:id="@+id/nav_news"
                 android:title="@string/news_nav_item_activity_event_showcase"/>

--- a/app/src/main/res/menu/event_showcase_drawer_view.xml
+++ b/app/src/main/res/menu/event_showcase_drawer_view.xml
@@ -3,7 +3,8 @@
     <group android:checkableBehavior="single">
         <item
                 android:id="@+id/nav_main"
-                android:title="@string/main_nav_item_activity_event_showcase"/>
+                android:title="@string/main_nav_item_activity_event_showcase"
+                android:checked="true"/>
         <item
                 android:id="@+id/nav_news"
                 android:title="@string/news_nav_item_activity_event_showcase"/>


### PR DESCRIPTION
Fixed back button behavior. Now pressing back button in annoter fragment than the main description fragment should bring us back to the description fragment. Furthermore, there should not be a blank screen anymore when pressing back button while being in the main fragment.