### PR TITLE
Migrate Sessions to Injectable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    sourceSets {
+        test { java.srcDirs = ['src/test/java', 'src/commonTest/java/'] }
+        androidTest { java.srcDirs = ['src/androidTest/java', 'src/commonTest/java/'] }
+    }
     testOptions {
         animationsDisabled = "true"
     }

--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/inject/TestComponent.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/inject/TestComponent.java
@@ -5,6 +5,7 @@ import ch.epfl.sweng.eventmanager.inject.ApplicationComponent;
 import ch.epfl.sweng.eventmanager.inject.ApplicationModule;
 import ch.epfl.sweng.eventmanager.test.repository.MockRepositoriesModule;
 import ch.epfl.sweng.eventmanager.repository.room.RoomModule;
+import ch.epfl.sweng.eventmanager.test.users.MockUsersModule;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.NewsFragmentTest;
 import dagger.Component;
 import dagger.android.AndroidInjectionModule;
@@ -18,7 +19,8 @@ import javax.inject.Singleton;
         ActivityBuilder.class,
         ApplicationModule.class,
         RoomModule.class,
-        MockRepositoriesModule.class})
+        MockRepositoriesModule.class,
+        MockUsersModule.class})
 @Singleton
 public interface TestComponent extends ApplicationComponent {
     void inject(NewsFragmentTest test);

--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/repository/MockEventsRepository.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/repository/MockEventsRepository.java
@@ -5,8 +5,7 @@ import android.graphics.Bitmap;
 import ch.epfl.sweng.eventmanager.repository.EventRepository;
 import ch.epfl.sweng.eventmanager.repository.data.*;
 import ch.epfl.sweng.eventmanager.test.ObservableMap;
-import ch.epfl.sweng.eventmanager.users.DummyInMemorySession;
-import ch.epfl.sweng.eventmanager.users.Role;
+import ch.epfl.sweng.eventmanager.test.users.DummyInMemorySession;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 

--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/users/MockUsersModule.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/users/MockUsersModule.java
@@ -1,0 +1,17 @@
+package ch.epfl.sweng.eventmanager.test.users;
+
+import ch.epfl.sweng.eventmanager.users.InMemorySession;
+import dagger.Binds;
+import dagger.Module;
+
+import javax.inject.Singleton;
+
+/**
+ * @author Louis Vialar
+ */
+@Module
+public abstract class MockUsersModule {
+    @Binds
+    @Singleton
+    public abstract InMemorySession providesInMemorySession(DummyInMemorySession repository);
+}

--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/NewsFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/NewsFragmentTest.java
@@ -10,7 +10,7 @@ import ch.epfl.sweng.eventmanager.ToastMatcher;
 import ch.epfl.sweng.eventmanager.test.EventTestRule;
 import ch.epfl.sweng.eventmanager.test.TestApplication;
 import ch.epfl.sweng.eventmanager.test.repository.MockNewsRepository;
-import ch.epfl.sweng.eventmanager.users.DummyInMemorySession;
+import ch.epfl.sweng.eventmanager.test.users.DummyInMemorySession;
 import ch.epfl.sweng.eventmanager.users.Session;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -33,6 +33,8 @@ public class NewsFragmentTest {
 
     @Inject
     MockNewsRepository repository;
+    @Inject
+    Session session;
 
 
     private String newsTitle = "A sweet news";
@@ -42,8 +44,7 @@ public class NewsFragmentTest {
     public void setup() {
         TestApplication.component.inject(this);
 
-        Session.enforceDummySessions();
-        Session.login(DummyInMemorySession.DUMMY_EMAIL, DummyInMemorySession.DUMMY_PASSWORD, null, null);
+        session.login(DummyInMemorySession.DUMMY_EMAIL, DummyInMemorySession.DUMMY_PASSWORD, null, null);
 
         onView(withId(R.id.drawer_layout))
                 .check(matches(isClosed(Gravity.LEFT)))

--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/userManager/LoginActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/ui/userManager/LoginActivityTest.java
@@ -1,16 +1,5 @@
 package ch.epfl.sweng.eventmanager.ui.userManager;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static android.support.test.espresso.action.ViewActions.typeText;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.hasErrorText;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.CoreMatchers.containsString;
-
 import android.content.Context;
 import android.os.SystemClock;
 import android.support.test.InstrumentationRegistry;
@@ -19,30 +8,25 @@ import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
-
+import ch.epfl.sweng.eventmanager.R;
 import junit.framework.AssertionFailedError;
-
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import ch.epfl.sweng.eventmanager.R;
-import ch.epfl.sweng.eventmanager.users.Session;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.*;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
 
 @RunWith(AndroidJUnit4.class)
 public class LoginActivityTest {
-    int MAX_RETRY_COUNT = 10;
-
-    @Before
-    public void disableFirebaseAuth() {
-        Session.enforceDummySessions();
-    }
-
     @Rule
     public final ActivityTestRule<LoginActivity> mActivityRule =
             new ActivityTestRule<>(LoginActivity.class);
+    int MAX_RETRY_COUNT = 10;
 
     @Test
     public void testSuccessfulLogin() {
@@ -66,7 +50,7 @@ public class LoginActivityTest {
                 break;
             } catch (AssertionFailedError e) {
                 Log.w("testSuccessfulLogin", "Waiting for authentication...");
-            } catch(NoMatchingViewException e) {
+            } catch (NoMatchingViewException e) {
                 // If the view does not exist, we switched to another activity!
                 break;
             }
@@ -107,7 +91,7 @@ public class LoginActivityTest {
                 break;
             } catch (AssertionFailedError e) {
                 Log.w("testSuccessfulLogin", "Waiting for authentication...");
-            } catch(NoMatchingViewException e) {
+            } catch (NoMatchingViewException e) {
                 // If the view does not exist, we switched to another activity!
                 break;
             }

--- a/app/src/commonTest/java/ch/epfl/sweng/eventmanager/test/users/DummyInMemorySession.java
+++ b/app/src/commonTest/java/ch/epfl/sweng/eventmanager/test/users/DummyInMemorySession.java
@@ -1,8 +1,11 @@
-package ch.epfl.sweng.eventmanager.users;
+package ch.epfl.sweng.eventmanager.test.users;
 
 import android.app.Activity;
 import android.content.Intent;
+import ch.epfl.sweng.eventmanager.users.InMemorySession;
 import com.google.android.gms.tasks.OnCompleteListener;
+
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import ch.epfl.sweng.eventmanager.repository.data.DummyUser;
@@ -15,7 +18,7 @@ import java.util.HashSet;
  * Dummy InMemorySession class, only used in tests.
  */
 @Singleton
-public class DummyInMemorySession implements InMemorySession{
+public class DummyInMemorySession implements InMemorySession {
     /**
      * Public in order to be used from the tests.
      */
@@ -25,6 +28,9 @@ public class DummyInMemorySession implements InMemorySession{
     public static final String DUMMY_DISPLAYNAME = "Lamb Da";
 
     private DummyUser user;
+
+    @Inject
+    public DummyInMemorySession() {}
 
     @Override
     public void login(String email, String password, Activity context, OnCompleteListener callback) {

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/inject/ApplicationComponent.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/inject/ApplicationComponent.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import ch.epfl.sweng.eventmanager.EventManagerApplication;
 import ch.epfl.sweng.eventmanager.repository.RepositoriesModule;
 import ch.epfl.sweng.eventmanager.repository.room.RoomModule;
+import ch.epfl.sweng.eventmanager.users.SessionModule;
 import dagger.BindsInstance;
 import dagger.Component;
 import dagger.android.AndroidInjectionModule;
@@ -21,6 +22,7 @@ import javax.inject.Singleton;
         ActivityBuilder.class,
         ApplicationModule.class,
         RepositoriesModule.class,
+        SessionModule.class,
         RoomModule.class})
 @Singleton
 public interface ApplicationComponent {

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventSelector/EventPickingActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventSelector/EventPickingActivity.java
@@ -30,6 +30,8 @@ public class EventPickingActivity extends AppCompatActivity {
     public static final String SELECTED_EVENT_ID = "ch.epfl.sweng.SELECTED_EVENT_ID";
     @Inject
     ViewModelFactory factory;
+    @Inject
+    Session session;
 
     private TextView joinedHelpText;
     private TextView notJoinedHelpText;
@@ -111,7 +113,7 @@ public class EventPickingActivity extends AppCompatActivity {
 
         // Login button
         Button loginButton = findViewById(R.id.login_button);
-        if (Session.isLoggedIn()) {
+        if (session.isLoggedIn()) {
             loginButton.setText(R.string.account_button);
         } else {
             loginButton.setText(R.string.login_button);
@@ -124,7 +126,7 @@ public class EventPickingActivity extends AppCompatActivity {
 
     public void openLoginOrAccountActivity(View view) {
        Class nextActivity;
-       if (Session.isLoggedIn()) {
+       if (session.isLoggedIn()) {
            nextActivity = DisplayAccountActivity.class;
        } else {
            nextActivity = LoginActivity.class;

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseActivity.java
@@ -44,6 +44,8 @@ public class EventShowcaseActivity extends AppCompatActivity
 
     @Inject
     ViewModelFactory factory;
+    @Inject
+    Session session;
 
     @BindView(R.id.drawer_layout)
     DrawerLayout mDrawerLayout;
@@ -125,7 +127,7 @@ public class EventShowcaseActivity extends AppCompatActivity
                             return;
                         }
 
-                        if (Session.isLoggedIn() && Session.isClearedFor(Role.ADMIN, ev)) {
+                        if (session.isLoggedIn() && session.isClearedFor(Role.ADMIN, ev)) {
                             MenuItem adminMenuItem = navigationView.getMenu().findItem(R.id.nav_admin);
                             adminMenuItem.setVisible(true);
                         }

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseModule.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/EventShowcaseModule.java
@@ -1,6 +1,7 @@
 package ch.epfl.sweng.eventmanager.ui.eventShowcase;
 
 import android.arch.lifecycle.ViewModel;
+import ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.NewsFragment;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments.SendNewsFragment;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.models.EventShowcaseModel;
 import ch.epfl.sweng.eventmanager.ui.eventShowcase.models.NewsViewModel;
@@ -42,5 +43,7 @@ public abstract class EventShowcaseModule {
 
     @ContributesAndroidInjector
     abstract SendNewsFragment contributeSendNewsFragmentInjector();
+    @ContributesAndroidInjector
+    abstract NewsFragment contributeNewsFragmentInjector();
 }
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/NewsFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/eventShowcase/fragments/NewsFragment.java
@@ -3,6 +3,7 @@ package ch.epfl.sweng.eventmanager.ui.eventShowcase.fragments;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.Transformations;
 import android.arch.lifecycle.ViewModelProviders;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.LinearLayoutManager;
@@ -23,7 +24,9 @@ import ch.epfl.sweng.eventmanager.users.Session;
 import com.twitter.sdk.android.core.models.Tweet;
 import com.twitter.sdk.android.core.models.TweetBuilder;
 import com.twitter.sdk.android.tweetui.CompactTweetView;
+import dagger.android.support.AndroidSupportInjection;
 
+import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 
@@ -36,10 +39,19 @@ public class NewsFragment extends AbstractShowcaseFragment {
     TextView emptyListTextView;
     @BindView(R.id.news_create_button)
     Button newsCreateButton;
+    @Inject
+    Session session;
     private NewsAdapter newsAdapter;
 
     public NewsFragment() {
         super(R.layout.fragment_news);
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        AndroidSupportInjection.inject(this);
+
+        super.onAttach(context);
     }
 
     @Override
@@ -71,7 +83,7 @@ public class NewsFragment extends AbstractShowcaseFragment {
         }
 
         super.model.getEvent().observe(this, ev -> {
-            if (Session.isClearedFor(Role.ADMIN, ev)) {
+            if (session.isClearedFor(Role.ADMIN, ev)) {
                 newsCreateButton.setVisibility(View.VISIBLE);
             } else {
                 newsCreateButton.setVisibility(View.GONE);

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/userManager/DisplayAccountActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/userManager/DisplayAccountActivity.java
@@ -10,17 +10,24 @@ import android.widget.TextView;
 import ch.epfl.sweng.eventmanager.R;
 import ch.epfl.sweng.eventmanager.ui.eventSelector.EventPickingActivity;
 import ch.epfl.sweng.eventmanager.users.Session;
+import dagger.android.AndroidInjection;
+
+import javax.inject.Inject;
 
 public class DisplayAccountActivity extends AppCompatActivity {
+    @Inject
+    Session session;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        AndroidInjection.inject(this);
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_display_account);
 
         // We assume the user is logged in when the activity is opened.
         TextView helpText = (TextView) findViewById(R.id.main_text);
-        helpText.setText("Logged as: " + Session.getCurrentUser().getEmail());
+        helpText.setText("Logged as: " + session.getCurrentUser().getEmail());
 
 
         Button logoutButton = (Button) findViewById(R.id.logout_button);
@@ -35,7 +42,7 @@ public class DisplayAccountActivity extends AppCompatActivity {
     }
 
     public void logoutThenRedirectToEventSelector(View view) {
-        Session.logout();
+        session.logout();
         openEventSelector(view);
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/userManager/LoginActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/userManager/LoginActivity.java
@@ -20,6 +20,8 @@ import ch.epfl.sweng.eventmanager.R;
 import ch.epfl.sweng.eventmanager.users.Session;
 import dagger.android.AndroidInjection;
 
+import javax.inject.Inject;
+
 /**
  * A login screen that offers login via email/password.
  */
@@ -32,6 +34,9 @@ public class LoginActivity extends AppCompatActivity {
     private EditText mPasswordView;
     private Button mLoginButton;
     private ProgressBar mProgressBar;
+
+    @Inject
+    Session session;
 
     private void setupFields() {
         mEmailView = findViewById(R.id.email_field);
@@ -111,7 +116,7 @@ public class LoginActivity extends AppCompatActivity {
             focusView.requestFocus();
         } else {
             showProgress(true);
-            Session.login(email, password, this, getSignInOnCompleteListener(this));
+            session.login(email, password, this, getSignInOnCompleteListener(this));
         }
     }
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/users/InMemoryFirebaseSession.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/users/InMemoryFirebaseSession.java
@@ -1,39 +1,39 @@
 package ch.epfl.sweng.eventmanager.users;
 
 import android.app.Activity;
-import android.content.Context;
-
+import ch.epfl.sweng.eventmanager.repository.data.FirebaseBackedUser;
+import ch.epfl.sweng.eventmanager.repository.data.User;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.firebase.auth.FirebaseAuth;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import ch.epfl.sweng.eventmanager.repository.data.FirebaseBackedUser;
-import ch.epfl.sweng.eventmanager.repository.data.User;
-
 @Singleton
-public class InMemoryFirebaseSession implements InMemorySession{
-    private final FirebaseAuth mAuth = FirebaseAuth.getInstance();
+public class InMemoryFirebaseSession implements InMemorySession {
+    @Inject
+    InMemoryFirebaseSession() {}
+
 
     @Override
     public void login(String email, String password, Activity context, OnCompleteListener callback) {
-        mAuth.signInWithEmailAndPassword(email, password)
+        FirebaseAuth.getInstance().signInWithEmailAndPassword(email, password)
                 .addOnCompleteListener(context, callback);
     }
 
     @Override
     public User getCurrentUser() {
-        if (mAuth.getCurrentUser() == null) return null;
-        else return new FirebaseBackedUser(mAuth.getCurrentUser());
+        if (FirebaseAuth.getInstance().getCurrentUser() == null) return null;
+        else return new FirebaseBackedUser(FirebaseAuth.getInstance().getCurrentUser());
     }
 
     @Override
     public boolean isLoggedIn() {
-        return (mAuth.getCurrentUser() != null);
+        return (FirebaseAuth.getInstance().getCurrentUser() != null);
     }
 
     @Override
     public void logout() {
-        mAuth.signOut();
+        FirebaseAuth.getInstance().signOut();
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/users/Session.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/users/Session.java
@@ -1,57 +1,53 @@
 package ch.epfl.sweng.eventmanager.users;
 
 import android.app.Activity;
-
+import ch.epfl.sweng.eventmanager.repository.data.Event;
+import ch.epfl.sweng.eventmanager.repository.data.User;
 import com.google.android.gms.tasks.OnCompleteListener;
+import dagger.Provides;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 
-import ch.epfl.sweng.eventmanager.repository.data.Event;
-import ch.epfl.sweng.eventmanager.repository.data.User;
-
+@Singleton
 public final class Session {
-    private static InMemorySession session;
+    private final InMemorySession session;
 
-    /**
-     * Used to lazily access the session since InMemoryFirebaseSession blows up when
-     * instantiated out of the emulator.
-     */
-    private static InMemorySession getSession() {
-       if (session == null) return new InMemoryFirebaseSession();
-       else return session;
+    @Inject
+    Session(InMemorySession session) {
+        this.session = session;
     }
 
-    /**
-     * Used in tests to bypass Firebase Auth which is broken in our CI.
-     */
-    public static void enforceDummySessions() {
-        session = new DummyInMemorySession();
+    private InMemorySession getSession() {
+        return session;
     }
 
-    public static User getCurrentUser() {
-       return getSession().getCurrentUser();
+    public User getCurrentUser() {
+        return getSession().getCurrentUser();
     }
 
-    public static boolean isLoggedIn() {
-       return getSession().isLoggedIn();
+    public boolean isLoggedIn() {
+        return getSession().isLoggedIn();
     }
 
-    public static void login(String email, String password, Activity context, OnCompleteListener callback) {
+    public void login(String email, String password, Activity context, OnCompleteListener callback) {
         getSession().login(email, password, context, callback);
     }
 
-    public static void logout() {
+    public void logout() {
         getSession().logout();
     }
 
     /**
      * Check whether the current session is allowed to access an event given a clearance level.
+     *
      * @param role requested clearance
-     * @param ev event to be accessed
+     * @param ev   event to be accessed
      * @return true is the user is cleared, false otherwise
      */
-    public static boolean isClearedFor(Role role, Event ev) {
+    public boolean isClearedFor(Role role, Event ev) {
         if (!isLoggedIn()) return false;
         if (ev == null || ev.getUsers() == null) return false;
         Map<String, List<String>> roleToUidMap = ev.getUsers();

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/users/SessionModule.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/users/SessionModule.java
@@ -1,0 +1,16 @@
+package ch.epfl.sweng.eventmanager.users;
+
+import dagger.Binds;
+import dagger.Module;
+
+import javax.inject.Singleton;
+
+/**
+ * @author Louis Vialar
+ */
+@Module
+public abstract class SessionModule {
+    @Binds
+    @Singleton
+    abstract InMemorySession providesMemorySession(InMemoryFirebaseSession session);
+}

--- a/app/src/test/java/ch/epfl/sweng/eventmanager/users/SessionTest.java
+++ b/app/src/test/java/ch/epfl/sweng/eventmanager/users/SessionTest.java
@@ -1,5 +1,6 @@
 package ch.epfl.sweng.eventmanager.users;
 
+import ch.epfl.sweng.eventmanager.test.users.DummyInMemorySession;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,17 +13,22 @@ import java.util.List;
 import ch.epfl.sweng.eventmanager.repository.data.Event;
 import ch.epfl.sweng.eventmanager.repository.data.Spot;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class SessionTest {
+    private Session session;
+
     @Before
-    public void disableFirebaseAuth() { Session.enforceDummySessions(); }
+    public void disableFirebaseAuth() { session = new Session(new DummyInMemorySession()); }
 
     @Test
     public void testAuthentication() {
-        assert(Session.isLoggedIn() == false);
-        Session.login(DummyInMemorySession.DUMMY_EMAIL, DummyInMemorySession.DUMMY_PASSWORD, null, null);
-        assert(Session.isLoggedIn() == true);
-        Session.logout();
-        assert(Session.isLoggedIn() == false);
+        assertFalse(session.isLoggedIn());
+        session.login(DummyInMemorySession.DUMMY_EMAIL, DummyInMemorySession.DUMMY_PASSWORD, null, null);
+        assertTrue(session.isLoggedIn());
+        session.logout();
+        assertFalse(session.isLoggedIn());
     }
 
     @Test
@@ -46,16 +52,16 @@ public class SessionTest {
                 null, null, null, spotList, unknownUserMapping, null);
 
         // The user is not logged in, supposed to fail cleanly
-        assert(Session.isClearedFor(Role.ADMIN, ev2) == false);
+        assertFalse(session.isClearedFor(Role.ADMIN, ev2));
 
         // User sign in
-        Session.login(DummyInMemorySession.DUMMY_EMAIL, DummyInMemorySession.DUMMY_PASSWORD,null, null);
-        assert(Session.isLoggedIn() == true);
+        session.login(DummyInMemorySession.DUMMY_EMAIL, DummyInMemorySession.DUMMY_PASSWORD,null, null);
+        assertTrue(session.isLoggedIn());
 
         //
-        assert(Session.isClearedFor(Role.ADMIN, ev1) == false);
-        assert(Session.isClearedFor(Role.ADMIN, ev2) == true);
-        assert(Session.isClearedFor(Role.STAFF, ev2) == false);
-        assert(Session.isClearedFor(Role.ADMIN, ev3) == false);
+        assertFalse(session.isClearedFor(Role.ADMIN, ev1));
+        assertTrue(session.isClearedFor(Role.ADMIN, ev2));
+        assertFalse(session.isClearedFor(Role.STAFF, ev2));
+        assertFalse(session.isClearedFor(Role.ADMIN, ev3));
     }
 }


### PR DESCRIPTION
This makes testing them easier, as we can mock the underlying `InMemorySession` easily, without having to include some test code in the main source directory.

This PR also creates a commonTest source directory, for classes that should be both in androidTest and test (see #126?)