### PR TITLE
Make currently static FirebaseCloudFunction injectable

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/repository/MockEventsRepository.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/repository/MockEventsRepository.java
@@ -2,6 +2,7 @@ package ch.epfl.sweng.eventmanager.test.repository;
 
 import android.graphics.Bitmap;
 
+import ch.epfl.sweng.eventmanager.repository.CloudFunction;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.gson.Gson;
@@ -30,7 +31,7 @@ import ch.epfl.sweng.eventmanager.users.DummyInMemorySession;
 /**
  * @author Louis Vialar
  */
-public class MockEventsRepository implements EventRepository {
+public class MockEventsRepository implements EventRepository, CloudFunction {
     public static final Map<Integer, EventTicketingConfiguration> CONFIG_BY_EVENT;
     public static final String EVENT_EMAIL = "events@not-really-epfl.ch";
     private static int CURRENT_EVENT_ID = 1000;
@@ -231,5 +232,20 @@ public class MockEventsRepository implements EventRepository {
     public Task<Event> updateEvent(Event event) {
         events.put(event.getId(), event);
         return Tasks.call(() -> event);
+    }
+
+    @Override
+    public Task<Boolean> addUserToEvent(String email, int eventId, String role) {
+        Event ev = events.get(eventId).getValue();
+        if (ev == null)
+            return Tasks.call(() -> false);
+
+        if (!ev.getUsers().containsKey(role))
+            ev.getUsers().put(role, new HashMap<>());
+
+        ev.getUsers().get(role).put(String.valueOf(System.currentTimeMillis()), email);
+        events.put(eventId, ev);
+
+        return Tasks.call(() -> true);
     }
 }

--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/repository/MockRepositoriesModule.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/repository/MockRepositoriesModule.java
@@ -2,6 +2,7 @@ package ch.epfl.sweng.eventmanager.test.repository;
 
 import javax.inject.Singleton;
 
+import ch.epfl.sweng.eventmanager.repository.CloudFunction;
 import ch.epfl.sweng.eventmanager.repository.EventRepository;
 import ch.epfl.sweng.eventmanager.repository.FeedbackRepository;
 import ch.epfl.sweng.eventmanager.repository.NewsRepository;
@@ -35,6 +36,12 @@ public class MockRepositoriesModule {
     @Provides
     @Singleton
     public EventRepository providesEventRepository(MockEventsRepository repository) {
+        return repository;
+    }
+
+    @Provides
+    @Singleton
+    public CloudFunction providesCloudFunction(MockEventsRepository repository) {
         return repository;
     }
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/CloudFunction.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/CloudFunction.java
@@ -1,0 +1,20 @@
+package ch.epfl.sweng.eventmanager.repository;
+
+import com.google.android.gms.tasks.Task;
+
+/**
+ * @author Louis Vialar
+ */
+public interface CloudFunction {
+
+    /**
+     * Calls a dedicated FireBase Cloud Function allowing an event administrator to add an user to
+     * its event.
+     *
+     * @param email   email of the target user
+     * @param eventId target event
+     * @param role    string representation role to be assigned to the target user
+     * @return the related task
+     */
+    Task<Boolean> addUserToEvent(String email, int eventId, String role);
+}

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/RepositoriesModule.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/RepositoriesModule.java
@@ -1,5 +1,6 @@
 package ch.epfl.sweng.eventmanager.repository;
 
+import ch.epfl.sweng.eventmanager.repository.impl.FirebaseCloudFunction;
 import ch.epfl.sweng.eventmanager.repository.impl.FirebaseEventRepository;
 import ch.epfl.sweng.eventmanager.repository.impl.FirebaseFeedbackRepository;
 import ch.epfl.sweng.eventmanager.repository.impl.FirebaseNewsRepository;
@@ -24,4 +25,8 @@ public abstract class RepositoriesModule {
     @Binds
     @Singleton
     abstract FeedbackRepository providesFeedbackRepository(FirebaseFeedbackRepository repository);
+
+    @Binds
+    @Singleton
+    abstract CloudFunction providesCloudFunction(FirebaseCloudFunction impl);
 }

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/impl/FirebaseCloudFunction.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/impl/FirebaseCloudFunction.java
@@ -1,26 +1,30 @@
 package ch.epfl.sweng.eventmanager.repository.impl;
 
-import com.google.android.gms.tasks.Continuation;
+import ch.epfl.sweng.eventmanager.repository.CloudFunction;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.functions.FirebaseFunctions;
-import com.google.firebase.functions.HttpsCallableResult;
 
+import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
+public class FirebaseCloudFunction implements CloudFunction {
 
-public class FirebaseCloudFunction {
+    @Inject
+    public FirebaseCloudFunction() {
+
+    }
+
     /**
      * Calls a dedicated FireBase Cloud Function allowing an event administrator to add an user to
      * its event.
      *
-     * @param email email of the target user
+     * @param email   email of the target user
      * @param eventId target event
-     * @param role string representation role to be assigned to the target user
+     * @param role    string representation role to be assigned to the target user
      * @return the related task
      */
-    public static Task<Boolean> addUserToEvent(String email, int eventId, String role) {
+    public Task<Boolean> addUserToEvent(String email, int eventId, String role) {
         // Prepare parameters for the Firebase Cloud Function
         Map<String, Object> data = new HashMap<>();
         data.put("eventId", eventId);

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/EventCreateActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/EventCreateActivity.java
@@ -3,32 +3,22 @@ package ch.epfl.sweng.eventmanager.ui.event.interaction;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.*;
-
-import javax.inject.Inject;
-
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.ViewModelProviders;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import ch.epfl.sweng.eventmanager.R;
 import ch.epfl.sweng.eventmanager.repository.EventRepository;
 import ch.epfl.sweng.eventmanager.repository.data.Event;
-import ch.epfl.sweng.eventmanager.repository.impl.FirebaseCloudFunction;
-import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.schedule.ScheduleParentFragment;
-import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.user.EventUserManagementFragment;
-import ch.epfl.sweng.eventmanager.ui.event.interaction.models.EventInteractionModel;
 import ch.epfl.sweng.eventmanager.ui.event.selection.EventPickingActivity;
 import ch.epfl.sweng.eventmanager.users.Session;
 import ch.epfl.sweng.eventmanager.viewmodel.ViewModelFactory;
-import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import dagger.android.AndroidInjection;
 
+import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/EventInteractionModule.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/EventInteractionModule.java
@@ -1,10 +1,8 @@
 package ch.epfl.sweng.eventmanager.ui.event.interaction;
 
 import androidx.lifecycle.ViewModel;
-import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.EventFeedbackFragment;
-import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.EventMainFragment;
-import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.EventMapFragment;
-import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.SendNewsFragment;
+import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.*;
+import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.user.EventUserManagementFragment;
 import ch.epfl.sweng.eventmanager.ui.event.interaction.models.EventInteractionModel;
 import ch.epfl.sweng.eventmanager.ui.event.interaction.models.NewsViewModel;
 import ch.epfl.sweng.eventmanager.ui.event.interaction.models.ScheduleViewModel;
@@ -66,4 +64,7 @@ public abstract class EventInteractionModule {
 
     @ContributesAndroidInjector
     abstract EventMainFragment contributeEventMainFragmentInjector();
+
+    @ContributesAndroidInjector
+    abstract EventUserManagementFragment contributeEventUserManagementFragmentInjector();
 }

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/fragments/EventUserManagementFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/fragments/EventUserManagementFragment.java
@@ -8,6 +8,7 @@ import ch.epfl.sweng.eventmanager.R;
  * Allows an administrator a manage the users allowed to work with this event (= access to admin
  * features).
  */
+//FIXME rename this class please! we already have one with the same name in the subpackage .user
 public class EventUserManagementFragment extends AbstractShowcaseFragment {
     private static final String TAG = "UserManagement";
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/fragments/user/EventUserManagementFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/fragments/user/EventUserManagementFragment.java
@@ -5,23 +5,19 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.ProgressBar;
-import android.widget.Spinner;
-import android.widget.TextView;
-import android.widget.Toast;
-
+import android.widget.*;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import ch.epfl.sweng.eventmanager.R;
+import ch.epfl.sweng.eventmanager.repository.CloudFunction;
 import ch.epfl.sweng.eventmanager.repository.data.Event;
-import ch.epfl.sweng.eventmanager.repository.impl.FirebaseCloudFunction;
 import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.AbstractShowcaseFragment;
 import ch.epfl.sweng.eventmanager.users.Role;
+import dagger.android.support.AndroidSupportInjection;
+
+import javax.inject.Inject;
 
 /**
  * Allows an administrator a manage the users allowed to work with this event (= access to admin
@@ -48,9 +44,18 @@ public class EventUserManagementFragment extends AbstractShowcaseFragment {
     @BindView(R.id.user_management_user_list_right_header)
     TextView rightHeader;
 
+    @Inject
+    CloudFunction cloudFunction;
+
     public EventUserManagementFragment() {
         // Required empty public constructor
         super(R.layout.fragment_event_user_management);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        AndroidSupportInjection.inject(this);
+        super.onCreate(savedInstanceState);
     }
 
     @Override
@@ -123,7 +128,7 @@ public class EventUserManagementFragment extends AbstractShowcaseFragment {
         setInProgressState(true);
         String email = mAddUserEmailField.getText().toString();
         String role = mAddUserSpinner.getSelectedItem().toString().toLowerCase();
-        FirebaseCloudFunction.addUserToEvent(email, ev.getId(), role)
+        cloudFunction.addUserToEvent(email, ev.getId(), role)
                 .addOnCompleteListener(task -> {
                     String toastText;
                     if (task.isSuccessful()) toastText = getString(R.string.add_user_success);


### PR DESCRIPTION
This PR replaces the FirebaseCloudFunction static class by a public interface and an injected implementation. It
also provides a basic mock implementation, that might be updated in the future if needed.
It then injects the new interface wherever the old class was used.