### PR TITLE
Change structure of per-event user rights

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/repository/MockEventsRepository.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/eventmanager/test/repository/MockEventsRepository.java
@@ -109,10 +109,8 @@ public class MockEventsRepository implements EventRepository, CloudFunction {
                 " \"latitude\" : 46.517365,\n        \"longitude\" :" +
                 " 6.566036\n      } ]\n    } ]";
 
-        Map<String, Map<String, String>> usersMap = new HashMap<>();
-        Map<String, String> userUids = new HashMap<>();
-        userUids.put("key1", DummyInMemorySession.DUMMY_UID);
-        usersMap.put("admin", userUids);
+        Map<String, String> usersMap = new HashMap<>();
+        usersMap.put(DummyInMemorySession.DUMMY_UID, "admin");
 
         addEvent(new Event(1, "Event with scheduled items", "Description", new Date(1550307600L), new Date(1550422800L),
                 orgaEmail, null, new EventLocation("EPFL", Position.EPFL), usersMap, "JapanImpact",
@@ -240,10 +238,7 @@ public class MockEventsRepository implements EventRepository, CloudFunction {
         if (ev == null)
             return Tasks.call(() -> false);
 
-        if (!ev.getUsers().containsKey(role))
-            ev.getUsers().put(role, new HashMap<>());
-
-        ev.getUsers().get(role).put(String.valueOf(System.currentTimeMillis()), email);
+        ev.getUsers().put(email, role);
         events.put(eventId, ev);
 
         return Tasks.call(() -> true);

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/Event.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/Event.java
@@ -4,6 +4,7 @@ import android.graphics.Bitmap;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public final class Event {
     /**
      * A map from roles to a list of user UIDs.
      */
-    private Map<String, Map<String, String>> users;
+    private Map<String, String> users;
 
     /**
      * The twitter account screen name
@@ -71,13 +72,13 @@ public final class Event {
     // TODO define if an event can have only empty and null atributes
     public Event(int id, String name, String description, Date beginDate, Date endDate,
                  String organizerEmail, Bitmap image, EventLocation location,
-                 Map<String, Map<String, String>> users, String twitterName) {
+                 Map<String, String> users, String twitterName) {
         this(id, name, description, beginDate, endDate, organizerEmail, image, location, users, twitterName, null);
     }
 
     public Event(int id, String name, String description, Date beginDate, Date endDate,
                  String organizerEmail, Bitmap image, EventLocation location,
-                 Map<String, Map<String, String>> users, String twitterName, EventTicketingConfiguration ticketingConfiguration) {
+                 Map<String, String> users, String twitterName, EventTicketingConfiguration ticketingConfiguration) {
         this.ticketingConfiguration = ticketingConfiguration;
 
         if (beginDate.getTime() > endDate.getTime())
@@ -142,7 +143,7 @@ public final class Event {
      *
      * @return firebase representation of user permissions.
      */
-    public Map<String, Map<String, String>> getUsers() { return users; }
+    public Map<String, String> getUsers() { return users; }
 
     /**
      * @return a map of Role permissions to User IDs
@@ -154,12 +155,13 @@ public final class Event {
         // Don't blow up if the event does not contain any permission data
         if (getUsers() == null) return result;
 
-
         // The keys of a Java Map are unique
-        for (String rawRole : getUsers().keySet()) {
-            Role role = Role.valueOf(rawRole.toUpperCase());
-            // TODO handle null pointer exception
-            List<String> users = new ArrayList<>(getUsers().get(rawRole).values());
+        for (String uid : getUsers().keySet()) {
+            Role role = Role.valueOf(getUsers().get(uid).toUpperCase());
+
+            List<String> users;
+            if (result.get(role) == null) users = Arrays.asList(uid);
+            else users = result.get(role);
 
             result.put(role, users);
         }
@@ -168,10 +170,8 @@ public final class Event {
     }
 
     // FIXME Use or delete method ?
-    public Collection<String> getUsersForRole(Role role) {
-       Map<String, String> uidMap = getUsers().get(role.toString().toLowerCase());
-       if (uidMap == null) return new ArrayList<>();
-       return uidMap.values();
+    public List<String> getUsersForRole(Role role) {
+        return getPermissions().get(role);
     }
 
     public String getTwitterName() {
@@ -230,7 +230,7 @@ public final class Event {
         this.location = location;
     }
 
-    public void setUsers(Map<String, Map<String, String>> users) {
+    public void setUsers(Map<String, String> users) {
         this.users = users;
     }
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/EventCreateActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/EventCreateActivity.java
@@ -80,9 +80,8 @@ public class EventCreateActivity extends AppCompatActivity {
     private Task<Event> prepareCreationTask() {
         if (eventID <= 0) {
             // Create the event and set the user admin of his event
-            Map<String, Map<String, String>> users = new HashMap<>();
-            users.put("admin", new HashMap<>());
-            users.get("admin").put("originalOwner", Session.getCurrentUser().getUid());
+            Map<String, String> users = new HashMap<>();
+            users.put(Session.getCurrentUser().getUid(), "admin");
 
             event.setUsers(users);
 

--- a/app/src/test/java/ch/epfl/sweng/eventmanager/users/SessionTest.java
+++ b/app/src/test/java/ch/epfl/sweng/eventmanager/users/SessionTest.java
@@ -28,17 +28,12 @@ public class SessionTest {
     @Test
     public void testClearance() {
         // Initialize used structures
-        Map<String, Map<String, String>> emptyUserMapping = new HashMap<>();
-        Map<String, Map<String, String>> adminUserMapping = new HashMap<>();
-        Map<String, Map<String, String>> unknownUserMapping = new HashMap<>();
+        Map<String, String> emptyUserMapping = new HashMap<>();
+        Map<String, String> adminUserMapping = new HashMap<>();
+        Map<String, String> unknownUserMapping = new HashMap<>();
 
-        HashMap<String, String> adminUids= new HashMap<>();
-        adminUids.put("key1", DummyInMemorySession.DUMMY_UID);
-        HashMap<String, String> dummyUids = new HashMap<>();
-        dummyUids.put("key2", "unknownUid");
-
-        adminUserMapping.put(Role.ADMIN.toString().toLowerCase(), adminUids);
-        unknownUserMapping.put(Role.ADMIN.toString().toLowerCase(), dummyUids);
+        adminUserMapping.put(DummyInMemorySession.DUMMY_UID, Role.ADMIN.toString().toLowerCase());
+        unknownUserMapping.put("unknownUid", Role.ADMIN.toString().toLowerCase());
 
         List<Spot> spotList = new ArrayList<>();
         Event ev1 = new Event(1, "Event 1", "Descr 1", new Date(0), new Date(0),


### PR DESCRIPTION
Due to limitations of the filtering rules of the realtime DB, we have to change the structure of the rights. This only affects the way we store rights and does not have any implication to other parts of the project. 