### PR TITLE
refactoring/classes used by the map

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/MultiDrawable.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/MultiDrawable.java
@@ -10,6 +10,10 @@ import java.util.List;
 
 /**
  * Draws up to four other drawables.
+ *
+ * Class from the Google Maps Android API.
+ * https://developers.google.com/maps/documentation/android-api/utility/
+ *
  */
 public class MultiDrawable extends Drawable {
 

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/SpotType.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/SpotType.java
@@ -1,7 +1,5 @@
 package ch.epfl.sweng.eventmanager.repository.data;
 
-import java.security.cert.CertPathValidatorException;
-
 /**
  * Represents all type of spot
  *

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/Zone.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/Zone.java
@@ -4,14 +4,13 @@ import android.graphics.Color;
 import com.google.android.gms.maps.model.PolygonOptions;
 import java.util.List;
 
+
 public class Zone {
     private List<Position> positions;
 
     public Zone(List<Position> positions) {
         this.positions = positions;
     }
-
-    public Zone() {}
 
     public PolygonOptions addPolygon() {
         PolygonOptions options = new PolygonOptions()

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/Zone.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/Zone.java
@@ -24,6 +24,11 @@ public class Zone {
     }
 
     /**
+     * empty contructor needed for firebase
+     */
+    public Zone(){}
+
+    /**
      * @return A PolygonOptions instance that represents the overlay
      */
     public PolygonOptions addPolygon() {

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/Zone.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/repository/data/Zone.java
@@ -4,14 +4,28 @@ import android.graphics.Color;
 import com.google.android.gms.maps.model.PolygonOptions;
 import java.util.List;
 
-
+/**
+ * This class represents a delineated geographical zone that is overlayed by a blue color using the
+ * addPolygon method.
+ *
+ * This zone is delineated using a list of geographical positions, that can be accessed using
+ * the getPositions method.
+ */
 public class Zone {
     private List<Position> positions;
 
+    /**
+     * constructor
+     *
+     * @param positions that delineated the zone
+     */
     public Zone(List<Position> positions) {
         this.positions = positions;
     }
 
+    /**
+     * @return A PolygonOptions instance that represents the overlay
+     */
     public PolygonOptions addPolygon() {
         PolygonOptions options = new PolygonOptions()
                 .fillColor(Color.argb(33,26, 149,244))
@@ -23,6 +37,9 @@ public class Zone {
         return options;
     }
 
+    /**
+     * @return the geographical positions that delineated the zone
+     */
     public List<Position> getPositions() {
         return positions;
     }

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/fragments/EventMapFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/fragments/EventMapFragment.java
@@ -39,7 +39,7 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProviders;
 import ch.epfl.sweng.eventmanager.R;
 import ch.epfl.sweng.eventmanager.repository.data.EventLocation;
-import ch.epfl.sweng.eventmanager.repository.data.MultiDrawable;
+import ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.map.MultiDrawable;
 import ch.epfl.sweng.eventmanager.repository.data.Spot;
 import ch.epfl.sweng.eventmanager.repository.data.Zone;
 import ch.epfl.sweng.eventmanager.ui.event.interaction.EventShowcaseActivity;

--- a/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/fragments/map/MultiDrawable.java
+++ b/app/src/main/java/ch/epfl/sweng/eventmanager/ui/event/interaction/fragments/map/MultiDrawable.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.eventmanager.repository.data;
+package ch.epfl.sweng.eventmanager.ui.event.interaction.fragments.map;
 
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;


### PR DESCRIPTION
Small changes after the review: [](https://github.com/Susanfe/sdp-event-management/issues/249#issue-389097890)

1. javadoc for the multidrawable and zone classes
2. move the MultiDrawable class to the new map package in the ui package
3. remove unused import and constructor
